### PR TITLE
Add JetBrains sponsorship to README with H1 heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,9 @@ $exampleDataSource->create(new Person(
 	age: 5,
 ));
 ```
+
+# Proudly sponsored by
+
+[JetBrains Open Source sponsorship program](https://www.jetbrains.com/community/opensource/)
+
+[![JetBrains logo.](https://resources.jetbrains.com/storage/products/company/brand/logos/jetbrains.svg)](https://www.jetbrains.com/community/opensource/)


### PR DESCRIPTION
This PR adds JetBrains sponsorship information to the README.md file with an H1 heading.